### PR TITLE
Add support for Django 3.2, deprecate support for Django < 2.0

### DIFF
--- a/simple_socialauth/__init__.py
+++ b/simple_socialauth/__init__.py
@@ -1,2 +1,2 @@
 from __future__ import unicode_literals
-__version__ = '2.0.0'
+__version__ = '3.0.0'

--- a/simple_socialauth/__init__.py
+++ b/simple_socialauth/__init__.py
@@ -1,2 +1,2 @@
 from __future__ import unicode_literals
-__version__ = '3.0.0'
+__version__ = '2.1.0'

--- a/simple_socialauth/models.py
+++ b/simple_socialauth/models.py
@@ -5,7 +5,7 @@ import json
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 
 from .providers import registry
 

--- a/simple_socialauth/urls.py
+++ b/simple_socialauth/urls.py
@@ -1,11 +1,11 @@
 from __future__ import unicode_literals
-from django.conf.urls import url
+from django.urls import path
 
 from . import views
 
 
 urlpatterns = [
-    url(r'^(?P<provider_type>[\w\-]+)/login/$', views.LoginView.as_view(), name='simple_socialauth-login'),
-    url(r'^(?P<provider_type>[\w\-]+)/callback/$', views.CallbackView.as_view(), name='simple_socialauth-login_callback'),
-    url(r'^(?P<provider_type>[\w\-]+)/complete/$', views.CompleteView.as_view(), name='simple_socialauth-login_complete'),
+    path(r'^(?P<provider_type>[\w\-]+)/login/$', views.LoginView.as_view(), name='simple_socialauth-login'),
+    path(r'^(?P<provider_type>[\w\-]+)/callback/$', views.CallbackView.as_view(), name='simple_socialauth-login_callback'),
+    path(r'^(?P<provider_type>[\w\-]+)/complete/$', views.CompleteView.as_view(), name='simple_socialauth-login_complete'),
 ]

--- a/simple_socialauth/urls.py
+++ b/simple_socialauth/urls.py
@@ -1,11 +1,11 @@
 from __future__ import unicode_literals
-from django.urls import path
+from django.urls import re_path
 
 from . import views
 
 
 urlpatterns = [
-    path(r'^(?P<provider_type>[\w\-]+)/login/$', views.LoginView.as_view(), name='simple_socialauth-login'),
-    path(r'^(?P<provider_type>[\w\-]+)/callback/$', views.CallbackView.as_view(), name='simple_socialauth-login_callback'),
-    path(r'^(?P<provider_type>[\w\-]+)/complete/$', views.CompleteView.as_view(), name='simple_socialauth-login_complete'),
+    re_path(r'^(?P<provider_type>[\w\-]+)/login/$', views.LoginView.as_view(), name='simple_socialauth-login'),
+    re_path(r'^(?P<provider_type>[\w\-]+)/callback/$', views.CallbackView.as_view(), name='simple_socialauth-login_callback'),
+    re_path(r'^(?P<provider_type>[\w\-]+)/complete/$', views.CompleteView.as_view(), name='simple_socialauth-login_complete'),
 ]

--- a/simple_socialauth/views.py
+++ b/simple_socialauth/views.py
@@ -7,7 +7,7 @@ from django.contrib.auth import login as auth_login, authenticate, get_user_mode
 from django.db import IntegrityError
 from django.shortcuts import redirect, render
 from django.views.generic import View
-from django.utils import six
+from six import text_type
 
 try:
     from django.urls import reverse
@@ -188,10 +188,10 @@ class CompleteView(BaseView):
             while True:
                 if needs_username and not user.username and SIMPLE_SOCIALAUTH_GENERATE_USERNAME:
                     h = hashlib.sha256()
-                    h.update(six.text_type(user_info.get('uid', '')).encode('utf8'))
+                    h.update(text_type(user_info.get('uid', '')).encode('utf8'))
                     h.update(provider_type.encode('utf8'))
                     h.update(email.encode('utf8'))
-                    h.update(six.text_type(datetime.datetime.now()).encode('utf8'))
+                    h.update(text_type(datetime.datetime.now()).encode('utf8'))
                     user.username = h.hexdigest()[:user._meta.get_field('username').max_length]
 
                 try:


### PR DESCRIPTION
Replace references to django.utils.encoding.python_2_unicode_compatible to new location, six.
Six is also no longer located in django.utils, so change references.

Change url references to re_path which was added in Django 2.0.